### PR TITLE
Using assertSame to make equals checking strict

### DIFF
--- a/tests/StockMutationsTest.php
+++ b/tests/StockMutationsTest.php
@@ -66,9 +66,9 @@ class StockMutationsTest extends TestCase
         $stockMutation = $this->stockModel->stockMutations->first();
         $referenceMutation = $this->referenceModel->stockMutations->first();
 
-        $this->assertEquals(1, $stockMutation->reference_id);
+        $this->assertSame('1', $stockMutation->reference_id);
         $this->assertEquals(ReferenceModel::class, $stockMutation->reference_type);
-        $this->assertEquals(1, $referenceMutation->stockable_id);
+        $this->assertSame('1', $referenceMutation->stockable_id);
         $this->assertEquals(StockModel::class, $referenceMutation->stockable_type);
     }
 }


### PR DESCRIPTION
As title, these assertions should use `assertSame` to make assert equals checking strict.